### PR TITLE
Python 3 string formatting (PEP3101)

### DIFF
--- a/Syntaxes/Python.tmLanguage
+++ b/Syntaxes/Python.tmLanguage
@@ -1171,7 +1171,7 @@
 		<key>constant_placeholder</key>
 		<dict>
 			<key>match</key>
-			<string>(?i:(%(\([a-z_]+\))?#?0?\-?[ ]?\+?([0-9]*|\*)(\.([0-9]*|\*))?[hL]?[a-z%])|(\{([\w]+)?\}))</string>
+			<string>(?i:(%(\([a-z_]+\))?#?0?\-?[ ]?\+?([0-9]*|\*)(\.([0-9]*|\*))?[hL]?[a-z%])|(\{([!\[\].:\w ]+)?\}))</string>
 			<key>name</key>
 			<string>constant.other.placeholder.python</string>
 		</dict>


### PR DESCRIPTION
Python 3 (and 2.6 / 2.7) introduces new string formatting. See http://www.python.org/dev/peps/pep-3101/ for details.
I've added syntax highlighting for this.

Examples of new formatting:
'{}'
'{231}'
'{text}'
'{thing[51]}'
'{thing.item!r:20}'
