### PR TITLE
The pattern for class entered a endline when closing the parenthesis.

### DIFF
--- a/Syntaxes/Python.tmLanguage
+++ b/Syntaxes/Python.tmLanguage
@@ -308,7 +308,7 @@
 					<key>contentName</key>
 					<string>meta.class.inheritance.python</string>
 					<key>end</key>
-					<string>(?=\)|:)</string>
+					<string>(?=\)\s*\:)</string>
 					<key>patterns</key>
 					<array>
 						<dict>


### PR DESCRIPTION
When typing the last parenthesis of a class a new line was immediatly entered without the colon being entered. This change copies the pattern from the function end pattern preventing the new line to be entered before you enter the colon.
