### PR TITLE
Avoid Python3 "list.remove(x): x not in list" error

### DIFF
--- a/Support/sitecustomize.py
+++ b/Support/sitecustomize.py
@@ -13,7 +13,8 @@ Also, sys.stdout and sys.stder are wrapped in a utf-8 codec writer.
 import sys, os
 
 # remove TM_BUNDLE_SUPPORT from the path.
-sys.path.remove(os.environ['TM_BUNDLE_SUPPORT'])
+if os.environ['TM_BUNDLE_SUPPORT'] in sys.path:
+  sys.path.remove(os.environ['TM_BUNDLE_SUPPORT'])
 
 # now import local sitecustomize
 try:


### PR DESCRIPTION
Every time TextMate2 updates (and refreshes this file), I get the following error running in-app with Python3 (Python works fine).

```
Error in sitecustomize; set PYTHONVERBOSE for traceback: ValueError: list.remove(x): x not in list
```

It looks like my sitecustomize is being run twice with Python3 (lines 20-25), which is provoking the error; the `os.environ['TM_BUNDLE_SUPPORT']` is removed the first time, so it gives an error trying to remove it the second.

This problem has also been looked at [here](https://github.com/mxcl/homebrew/pull/16848) and [here](https://github.com/textmate/textmate/issues/812).
