### PR TITLE
Updated snippets to use Python 3 syntax for except.

### DIFF
--- a/Snippets/Try:Except.tmSnippet
+++ b/Snippets/Try:Except.tmSnippet
@@ -5,7 +5,7 @@
 	<key>content</key>
 	<string>try:
 	${1:pass}
-except ${2:Exception}, ${3:e}:
+except ${2:Exception} as ${3:e}:
 	${4:raise $3}</string>
 	<key>name</key>
 	<string>Try/Except</string>

--- a/Snippets/Try:Except:Else.tmSnippet
+++ b/Snippets/Try:Except:Else.tmSnippet
@@ -5,7 +5,7 @@
 	<key>content</key>
 	<string>try:
 	${1:pass}
-except ${2:Exception}, ${3:e}:
+except ${2:Exception} as ${3:e}:
 	${4:raise $3}
 else:
 	${5:pass}</string>

--- a/Snippets/Try:Except:Else:Finally.tmSnippet
+++ b/Snippets/Try:Except:Else:Finally.tmSnippet
@@ -5,7 +5,7 @@
 	<key>content</key>
 	<string>try:
 	${1:pass}
-except${2: ${3:Exception}, ${4:e}}:
+except${2: ${3:Exception} as ${4:e}}:
 	${5:raise}
 else:
 	${6:pass}

--- a/Snippets/Try:Except:Finally.tmSnippet
+++ b/Snippets/Try:Except:Finally.tmSnippet
@@ -5,7 +5,7 @@
 	<key>content</key>
 	<string>try:
 	${1:pass}
-except ${2:Exception}, ${3:e}:
+except ${2:Exception} as ${3:e}:
 	${4:raise $3}
 finally:
 	${5:pass}</string>


### PR DESCRIPTION
This change fixes the `try...` snippets to use the form of the `except` statement which is required by Python 3.  This syntax was [back-ported to Python 2.6 and later](http://www.python.org/dev/peps/pep-3110/#implementation).
