### PR TITLE
Fix highlighting of character classes containing opening brackets

### DIFF
--- a/Syntaxes/Regular Expressions (Python).tmLanguage
+++ b/Syntaxes/Regular Expressions (Python).tmLanguage
@@ -214,10 +214,14 @@
 			<key>include</key>
 			<string>#character-class</string>
 		</dict>
+		<dict>
+			<key>include</key>
+			<string>#character-class-contents</string>
+		</dict>
 	</array>
 	<key>repository</key>
 	<dict>
-		<key>character-class</key>
+		<key>character-class-contents</key>
 		<dict>
 			<key>patterns</key>
 			<array>
@@ -233,6 +237,12 @@
 					<key>name</key>
 					<string>constant.character.escape.backslash.regexp</string>
 				</dict>
+			</array>
+		</dict>
+		<key>character-class</key>
+		<dict>
+			<key>patterns</key>
+			<array>
 				<dict>
 					<key>begin</key>
 					<string>(\[)(\^)?</string>
@@ -265,7 +275,7 @@
 					<array>
 						<dict>
 							<key>include</key>
-							<string>#character-class</string>
+							<string>#character-class-contents</string>
 						</dict>
 						<dict>
 							<key>captures</key>


### PR DESCRIPTION
The character-class repository was recursively including itself, which meant that the grammar was saying it was possible to start one character class inside another.

This does not match the semantics of Python regular expressions. Opening brackets inside character classes are interpreted as literal characters, not as opening another, nested character class.

To fix this, I split the character-class repository in two: the character-class now handles matching the entire character class, while the character-class-contents repository handles matching just characters inside the character class.

This fixes the parsing of Python regular expressions like `r'[[]'`.

@sorbits We ran into this when testing out TextMate highlighting on GitHub's staging servers.

/cc @vmg
