### PR TITLE
Changed shebang and allows iTerm

### DIFF
--- a/Commands/Run Script in Python.plist
+++ b/Commands/Run Script in Python.plist
@@ -9,6 +9,11 @@
 [[ -z "$TM_FILEPATH" ]] &amp;&amp; TM_TMPFILE=$(mktemp -t pythonInTerm)
 : "${TM_FILEPATH:=$TM_TMPFILE}"; cat &gt;"$TM_FILEPATH"
 
+# run script in either Terminal.app or iTerm.app
+# according to the user's value for TM_TERM_PROG
+# default to Terminal.app since that is standard.
+
+TP=${TM_TERM_PROG:=Terminal}
 TPY=${TM_PYTHON:-pythonw}
 
 esc () {
@@ -20,14 +25,28 @@ STR="$1" ruby18 &lt;&lt;"RUBY"
 RUBY
 }
 
-osascript &lt;&lt;- APPLESCRIPT
-	tell app "Terminal"
-	    launch
-	    activate
-	    do script "clear; cd $(esc "${TM_DIRECTORY}"); $(esc "${TPY}") $(esc "${TM_FILEPATH}"); rm -f $(esc "${TM_TMPFILE}")"
-	    set position of first window to { 100, 100 }
-	end tell
+if [ "$TP" == iTerm ]; then
+    osascript &lt;&lt;END
+        tell application "iTerm"
+            activate
+            tell the current terminal
+                launch session "TextMate"
+                tell the last session
+                    write text "clear; cd $(esc "${TM_DIRECTORY}"); $(esc "${TPY}") $(esc "${TM_FILEPATH}"); rm -f $(esc "${TM_TMPFILE}")" 
+                end tell
+            end tell
+        end tell
+END
+else
+    osascript &lt;&lt;APPLESCRIPT
+        tell app "Terminal"
+            launch
+            activate
+            do script "clear; cd $(esc "${TM_DIRECTORY}"); $(esc "${TPY}") $(esc "${TM_FILEPATH}"); rm -f $(esc "${TM_TMPFILE}")"
+            set position of first window to { 100, 100 }
+            end tell
 APPLESCRIPT
+fi
 
 </string>
 	<key>input</key>

--- a/Commands/Run Script in Python.plist
+++ b/Commands/Run Script in Python.plist
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/bin/bash
+	<string>#!/usr/bin/env bash
 [[ -z "$TM_FILEPATH" ]] &amp;&amp; TM_TMPFILE=$(mktemp -t pythonInTerm)
 : "${TM_FILEPATH:=$TM_TMPFILE}"; cat &gt;"$TM_FILEPATH"
 


### PR DESCRIPTION
* Changed shebang line to '/usr/bin/env bash' per standard practice
* Allows running the script in iTerm.app instead of the default Terminal.app, using the user's value of the environment variable TM_TERM_PROG, defaulting to Terminal.app. This practice already exists in the command 'Debug Script in Terminal' in the same bundle, I simply adapted it to this command which runs the script normally rather than with the debugger.