### PR TITLE
Shebang to /bin/bash, iTerm support, new snippet

### DIFF
--- a/Commands/Check Python Syntax.plist
+++ b/Commands/Check Python Syntax.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>beforeRunningCommand</key>
@@ -9,24 +9,35 @@
 	<key>columnCaptureRegister</key>
 	<string>3</string>
 	<key>command</key>
-	<string>TPY=${TM_PYTHON:-python}
+	<string>#!/bin/bash
+[[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
+
+TPY=${TM_PYTHON:-python}
 
 "$TPY" "$TM_BUNDLE_SUPPORT/bin/pycheckmate.py" "$TM_FILEPATH"</string>
 	<key>fileCaptureRegister</key>
 	<string>1</string>
 	<key>input</key>
 	<string>none</string>
+	<key>inputFormat</key>
+	<string>text</string>
 	<key>keyEquivalent</key>
 	<string>^V</string>
 	<key>lineCaptureRegister</key>
 	<string>2</string>
 	<key>name</key>
 	<string>Validate Syntax (PyCheckMate)</string>
-	<key>output</key>
-	<string>showAsHTML</string>
+	<key>outputCaret</key>
+	<string>afterOutput</string>
+	<key>outputFormat</key>
+	<string>html</string>
+	<key>outputLocation</key>
+	<string>newWindow</string>
 	<key>scope</key>
 	<string>source.python</string>
 	<key>uuid</key>
 	<string>44C9C59C-89F9-11D9-9326-000D93B6E43C</string>
+	<key>version</key>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Commands/Cleanup Whitespace.plist
+++ b/Commands/Cleanup Whitespace.plist
@@ -1,20 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>"${TM_PYTHON:-python}" "${TM_BUNDLE_SUPPORT}/cleanup_whitespace.py"</string>
+	<string>#!/bin/bash
+[[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
+
+"${TM_PYTHON:-python}" "${TM_BUNDLE_SUPPORT}/cleanup_whitespace.py"</string>
 	<key>input</key>
 	<string>selection</string>
+	<key>inputFormat</key>
+	<string>text</string>
 	<key>name</key>
 	<string>Cleanup Whitespace</string>
-	<key>output</key>
-	<string>replaceSelectedText</string>
+	<key>outputCaret</key>
+	<string>heuristic</string>
+	<key>outputFormat</key>
+	<string>text</string>
+	<key>outputLocation</key>
+	<string>replaceInput</string>
 	<key>scope</key>
 	<string>source.python</string>
 	<key>uuid</key>
 	<string>95FFEECE-73E4-4B33-9CAE-1641C62FFBC0</string>
+	<key>version</key>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Commands/Debug Script in Terminal.plist
+++ b/Commands/Debug Script in Terminal.plist
@@ -9,12 +9,24 @@
 [[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
 
 # start up Python in debug mode using either Terminal.app or iTerm.app
-# according to the user's value for TM_TERM_PROG
-# Default to Terminal.app since that is standard.
-TP=${TM_TERM_PROG:=Terminal}
+# if iTerm is open or if TM_TERMINAL is set to iTerm then use iTerm
+# otherwise default to Terminal.app since that is standard.
+TP=${TM_TERMINAL:=Terminal}
 TPY=${TM_PYTHON:=python}
 
-if [ "$TP" == iTerm ]; then
+iTerm_running () {
+    ruby &lt;&lt;"RUBY"
+        all = `ps -U "$USER" -o ucomm`
+        split = all.split("\n")
+        if split.find { |cmd| 'iTerm' == cmd.strip }
+            STDOUT.write 0
+        else
+            STDOUT.write 1
+        end
+RUBY
+}
+
+if [ "$TP" == iTerm ] || [ $(iTerm_running) == 0 ]; then
     osascript &lt;&lt;END
         tell application "iTerm"
             activate

--- a/Commands/Debug Script in Terminal.plist
+++ b/Commands/Debug Script in Terminal.plist
@@ -5,7 +5,10 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string># start up Python in debug mode using either Terminal.app or iTerm.app
+	<string>#!/bin/bash
+[[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
+
+# start up Python in debug mode using either Terminal.app or iTerm.app
 # according to the user's value for TM_TERM_PROG
 # Default to Terminal.app since that is standard.
 TP=${TM_TERM_PROG:=Terminal}
@@ -35,15 +38,23 @@ fi
 </string>
 	<key>input</key>
 	<string>none</string>
+	<key>inputFormat</key>
+	<string>text</string>
 	<key>keyEquivalent</key>
 	<string>@D</string>
 	<key>name</key>
 	<string>Debug Script in Terminal</string>
-	<key>output</key>
+	<key>outputCaret</key>
+	<string>afterOutput</string>
+	<key>outputFormat</key>
+	<string>text</string>
+	<key>outputLocation</key>
 	<string>discard</string>
 	<key>scope</key>
 	<string>source.python</string>
 	<key>uuid</key>
 	<string>504278F6-89F4-11D9-9326-000D93B6E43C</string>
+	<key>version</key>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Commands/Documentation for Current Word.tmCommand
+++ b/Commands/Documentation for Current Word.tmCommand
@@ -5,7 +5,10 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string># set up TM_FIRST_LINE containing the first line of the script.
+	<string>#!/bin/bash
+[[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
+
+# set up TM_FIRST_LINE containing the first line of the script.
 read first_line
 0&lt;&amp;- # close STDIN
 export TM_FIRST_LINE="$first_line"
@@ -59,15 +62,23 @@ PYTHON
 </string>
 	<key>input</key>
 	<string>document</string>
+	<key>inputFormat</key>
+	<string>text</string>
 	<key>keyEquivalent</key>
 	<string>^h</string>
 	<key>name</key>
 	<string>Documentation for Current Word</string>
-	<key>output</key>
-	<string>showAsHTML</string>
+	<key>outputCaret</key>
+	<string>afterOutput</string>
+	<key>outputFormat</key>
+	<string>html</string>
+	<key>outputLocation</key>
+	<string>newWindow</string>
 	<key>scope</key>
 	<string>source.python</string>
 	<key>uuid</key>
 	<string>443BBF21-6124-4486-BFCA-D18606465885</string>
+	<key>version</key>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Commands/Documentation for Module.plist
+++ b/Commands/Documentation for Module.plist
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string># This command takes the currently selected word and
+	<string>#!/bin/bash
+[[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
+
+# This command takes the currently selected word and
 # displays the python documentation for the module
 # corresponding to said word.
 #
@@ -26,15 +29,23 @@ fi
 </string>
 	<key>input</key>
 	<string>none</string>
+	<key>inputFormat</key>
+	<string>text</string>
 	<key>keyEquivalent</key>
 	<string></string>
 	<key>name</key>
 	<string>Documentation for Module</string>
-	<key>output</key>
-	<string>showAsHTML</string>
+	<key>outputCaret</key>
+	<string>afterOutput</string>
+	<key>outputFormat</key>
+	<string>html</string>
+	<key>outputLocation</key>
+	<string>newWindow</string>
 	<key>scope</key>
 	<string>source.python</string>
 	<key>uuid</key>
 	<string>5BBD932E-7BB0-11D9-8E83-000D93B6E43C</string>
+	<key>version</key>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Commands/Documentation in Browser.plist
+++ b/Commands/Documentation in Browser.plist
@@ -1,26 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>TPY=${TM_PYTHON:-python}
+	<string>#!/bin/bash
+[[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
+
+TPY=${TM_PYTHON:-python}
 
 echo '&lt;html&gt;&lt;body&gt;'
 "$TPY" "${TM_BUNDLE_SUPPORT}/browse_pydocs.py"
 echo '&lt;/body&gt;&lt;/html&gt;'</string>
 	<key>input</key>
 	<string>none</string>
+	<key>inputFormat</key>
+	<string>text</string>
 	<key>keyEquivalent</key>
 	<string>^H</string>
 	<key>name</key>
 	<string>Documentation in Browser</string>
-	<key>output</key>
-	<string>showAsHTML</string>
+	<key>outputCaret</key>
+	<string>afterOutput</string>
+	<key>outputFormat</key>
+	<string>html</string>
+	<key>outputLocation</key>
+	<string>newWindow</string>
 	<key>scope</key>
 	<string>source.python</string>
 	<key>uuid</key>
 	<string>095E8342-FAED-4B95-A229-E245B0B601A7</string>
+	<key>version</key>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Commands/Run Project Unittests.plist
+++ b/Commands/Run Project Unittests.plist
@@ -9,7 +9,7 @@
 	<key>capturePattern</key>
 	<string>^\s*File "(.+)", line (\d+)</string>
 	<key>command</key>
-	<string>#!/usr/bin/env bash
+	<string>#!/bin/bash
 [[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
 
 # Find all files that end with "Test.py" and run 

--- a/Commands/Run Script in Python.plist
+++ b/Commands/Run Script in Python.plist
@@ -9,6 +9,10 @@
 [[ -z "$TM_FILEPATH" ]] &amp;&amp; TM_TMPFILE=$(mktemp -t pythonInTerm)
 : "${TM_FILEPATH:=$TM_TMPFILE}"; cat &gt;"$TM_FILEPATH"
 
+# run script using either Terminal.app or iTerm.app
+# if iTerm is open or if TM_TERMINAL is set to iTerm then use iTerm
+# otherwise default to Terminal.app since that is standard.
+TP=${TM_TERMINAL:=Terminal}
 TPY=${TM_PYTHON:-pythonw}
 
 esc () {
@@ -20,15 +24,39 @@ STR="$1" ruby18 &lt;&lt;"RUBY"
 RUBY
 }
 
-osascript &lt;&lt;- APPLESCRIPT
-	tell app "Terminal"
-	    launch
-	    activate
-	    do script "clear; cd $(esc "${TM_DIRECTORY}"); $(esc "${TPY}") $(esc "${TM_FILEPATH}"); rm -f $(esc "${TM_TMPFILE}")"
-	    set position of first window to { 100, 100 }
-	end tell
-APPLESCRIPT
+iTerm_running () {
+    ruby &lt;&lt;"RUBY"
+        all = `ps -U "$USER" -o ucomm`
+        split = all.split("\n")
+        if split.find { |cmd| 'iTerm' == cmd.strip }
+            STDOUT.write 0
+        else
+            STDOUT.write 1
+        end
+RUBY
+}
 
+if [ "$TP" == iTerm ] || [ $(iTerm_running) == 0 ]; then
+    osascript &lt;&lt;END
+        tell application "iTerm"
+            activate
+            tell the current terminal            
+                tell (launch session "TextMate")
+                    write text "clear; cd $(esc "${TM_DIRECTORY}"); $(esc "${TPY}") $(esc "${TM_FILEPATH}"); rm -f $(esc "${TM_TMPFILE}")"
+                end tell
+            end tell
+        end tell
+END
+else
+    osascript &lt;&lt;- APPLESCRIPT
+    	tell app "Terminal"
+    	    launch
+    	    activate
+    	    do script "clear; cd $(esc "${TM_DIRECTORY}"); $(esc "${TPY}") $(esc "${TM_FILEPATH}"); rm -f $(esc "${TM_TMPFILE}")"
+    	    set position of first window to { 100, 100 }
+    	end tell
+APPLESCRIPT
+fi
 </string>
 	<key>input</key>
 	<string>document</string>

--- a/Snippets/#!:usr:bin:env python3.tmSnippet
+++ b/Snippets/#!:usr:bin:env python3.tmSnippet
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>content</key>
+	<string>#!/usr/bin/env python3
+</string>
+	<key>name</key>
+	<string>#!/usr/bin/env python3</string>
+	<key>scope</key>
+	<string>L:dyn.caret.begin.document</string>
+	<key>tabTrigger</key>
+	<string>py3</string>
+	<key>uuid</key>
+	<string>6F354D26-BD1B-4AF8-9FE6-3839B97848ED</string>
+</dict>
+</plist>


### PR DESCRIPTION
The new snippet should go into `insert` and just below the current python shebang snippet, thanks.
See commit comments for details. Not sure about what happened to plist metadatas, I did not manually change them.