### PR TITLE
Support versioned python in first line

### DIFF
--- a/Syntaxes/Python.tmLanguage
+++ b/Syntaxes/Python.tmLanguage
@@ -17,7 +17,7 @@
 		<string>gypi</string>
 	</array>
 	<key>firstLineMatch</key>
-	<string>^#!/.*\bpython\b</string>
+	<string>^#!/.*\bpython[\d\.]*\b</string>
 	<key>keyEquivalent</key>
 	<string>^~P</string>
 	<key>name</key>


### PR DESCRIPTION
The current first line match only matches `\bpython\b`, which means it doesn’t match hashbang lines with python executables containing a version number, like `python3` which is inserted by the `py3` first line snippet.
This means that when in a new file I expand `py3` the file isn’t switched to Python.

This change adds support for versions in the executable names (including periods like in `python2.7`).