### PR TITLE
Fixed pycheckmate to python2

### DIFF
--- a/Support/bin/pycheckmate.py
+++ b/Support/bin/pycheckmate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # encoding: utf-8
 #
 # PyCheckMate, a PyChecker output beautifier for TextMate.


### PR DESCRIPTION
pycheckmate is currently not python3 compatible (decoding of bytes is assumed implicitly, usage of basestring and possibly more issues) and will break if the default python is python3