### PR TITLE
Official replacement of pep8 with pycodestyle

### DIFF
--- a/Support/bin/pycheckmate.py
+++ b/Support/bin/pycheckmate.py
@@ -13,8 +13,8 @@
 # - Install PyChecker or PyFlakes for more extensive checking. If both are
 #   installed, PyChecker will be used.
 # - TM_PYCHECKER may be set to control which checker is used. Set it to just
-#   "pychecker", "pyflakes", "pep8", "flake8", or "pylint", or "frosted" to
-#   locate these programs in the default python bin directory or to a full
+#   "pychecker", "pyflakes", "pycodestyle", "flake8", or "pylint", or "frosted"
+#   to locate these programs in the default python bin directory or to a full
 #   path if the checker program is installed elsewhere.
 # - If for some reason you want to use the built-in sytax check when either
 #   pychecker or pyflakes are installed, you may set TM_PYCHECKER to
@@ -44,7 +44,7 @@ else:
 PYCHECKER_URL = "http://pychecker.sourceforge.net/"
 PYFLAKES_URL = "http://divmod.org/projects/pyflakes"
 PYLINT_URL = "http://www.logilab.org/857"
-PEP8_URL = "http://pypi.python.org/pypi/pep8"
+PYCODESTYLE_URL = "https://pypi.python.org/pypi/pycodestyle"
 FLAKE8_URL = "http://pypi.python.org/pypi/flake8/"
 
 # patterns to match output of checker programs
@@ -245,7 +245,7 @@ def check_syntax(script_path):
             print('<span class="stderr">%s%s</span><br>' % (pad, line))
 
 def find_checker_program():
-    checkers = ["pychecker", "pyflakes", "pylint", "pep8", "flake8"]
+    checkers = ["pychecker", "pyflakes", "pylint", "pycodestyle", "flake8"]
     tm_pychecker = os.getenv("TM_PYCHECKER")
 
     opts = filter(None, os.getenv('TM_PYCHECKER_OPTIONS', '').split())
@@ -303,7 +303,7 @@ def find_checker_program():
             if status is None and not output:
                 return (checker, opts, "PyFlakes")
 
-        elif basename == "pep8":
+        elif basename == "pycodestyle":
             p = os.popen('"%s" --version 2>/dev/null' % (checker))
             version = p.readline().strip()
             status = p.close()
@@ -377,11 +377,11 @@ def main(script_path):
         pychecker_url = href_format % (PYCHECKER_URL, "PyChecker")
         pyflakes_url  = href_format % (PYFLAKES_URL, "PyFlakes")
         pylint_url  = href_format % (PYLINT_URL, "Pylint")
-        pep8_url = href_format % (PEP8_URL, "PEP 8")
+        pycodestyle_url = href_format % (PYCODESTYLE_URL, "PEP 8")
         flake8_url = href_format % (FLAKE8_URL, "flake8")
         warning_string = \
             "<p>Please install %s, %s, %s, %s or %s for more extensive code checking." \
-            "</p><br>" % (pychecker_url, pyflakes_url, pylint_url, pep8_url, flake8_url)
+            "</p><br>" % (pychecker_url, pyflakes_url, pylint_url, pycodestyle_url, flake8_url)
 
     basepath = os.getenv("TM_PROJECT_DIRECTORY")
     if basepath:


### PR DESCRIPTION
As of pep8 1.7.1 (2017-10-22) pep8 prominently warns on install and on use: "the tool is no longer released as pep8 and will only be fixed in the pycodestyle package." https://pypi.python.org/pypi/pep8

This change to the new tool: https://pypi.python.org/pypi/pycodestyle