### PR TITLE
Improve syntax highlighting of SQL queries

### DIFF
--- a/Syntaxes/Python.tmLanguage
+++ b/Syntaxes/Python.tmLanguage
@@ -2875,51 +2875,6 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>(""")(?=\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER))</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.string.begin.python</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>double quoted string</string>
-					<key>end</key>
-					<string>"""</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.string.end.python</string>
-						</dict>
-					</dict>
-					<key>name</key>
-					<string>string.quoted.double.block.sql.python</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#constant_placeholder</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#escaped_unicode_char</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#escaped_char</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>source.sql</string>
-						</dict>
-					</array>
-				</dict>
-				<dict>
-					<key>begin</key>
 					<string>(")(?=\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER))</string>
 					<key>beginCaptures</key>
 					<dict>
@@ -3009,16 +2964,52 @@
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>#constant_placeholder</string>
+							<key>begin</key>
+							<string>(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER))</string>
+							<key>end</key>
+							<string>(?=""")</string>
+							<key>name</key>
+							<string>string.quoted.double.block.sql.python</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#constant_placeholder</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#escaped_unicode_char</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#escaped_char</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>source.sql</string>
+								</dict>
+							</array>
 						</dict>
 						<dict>
-							<key>include</key>
-							<string>#escaped_unicode_char</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#escaped_char</string>
+							<key>begin</key>
+							<string>(?=\S)</string>
+							<key>end</key>
+							<string>(?=""")</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#constant_placeholder</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#escaped_unicode_char</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#escaped_char</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
@@ -3812,51 +3803,6 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>(''')(?=\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER))</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.string.begin.python</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>single quoted string</string>
-					<key>end</key>
-					<string>'''</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.string.end.python</string>
-						</dict>
-					</dict>
-					<key>name</key>
-					<string>string.quoted.single.block.python</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#constant_placeholder</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#escaped_unicode_char</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#escaped_char</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>source.sql</string>
-						</dict>
-					</array>
-				</dict>
-				<dict>
-					<key>begin</key>
 					<string>(')(?=\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER))</string>
 					<key>beginCaptures</key>
 					<dict>
@@ -3946,16 +3892,52 @@
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>#constant_placeholder</string>
+							<key>begin</key>
+							<string>(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER))</string>
+							<key>end</key>
+							<string>(?=''')</string>
+							<key>name</key>
+							<string>string.quoted.single.block.sql.python</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#constant_placeholder</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#escaped_unicode_char</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#escaped_char</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>source.sql</string>
+								</dict>
+							</array>
 						</dict>
 						<dict>
-							<key>include</key>
-							<string>#escaped_unicode_char</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#escaped_char</string>
+							<key>begin</key>
+							<string>(?=\S)</string>
+							<key>end</key>
+							<string>(?=''')</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#constant_placeholder</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#escaped_unicode_char</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#escaped_char</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
Previously, triple-quoted block strings that started with
whitespace (excluding newlines) then a SQL word were highlighted
to be SQL queries.

This commit removes the "excluding newlines" caveat. Here's an
example of something that gets SQL-highlighted when it didn't
used to be:

```python
    really_long_idk_wtf_bbq.connection.execute("""
        SELECT * FROM blah WHERE blah blah blah blah
    """)
```