### PR TITLE
Small fixes

### DIFF
--- a/Commands/Check Python Syntax.plist
+++ b/Commands/Check Python Syntax.plist
@@ -11,7 +11,7 @@
 	<key>command</key>
 	<string>#!/bin/bash
 
-TPY=${TM_PYTHON:-python}
+TPY=${TM_PYTHON:-python2}
 
 "$TPY" "$TM_BUNDLE_SUPPORT/bin/pycheckmate.py" "$TM_FILEPATH"</string>
 	<key>fileCaptureRegister</key>

--- a/Commands/Cleanup Whitespace.plist
+++ b/Commands/Cleanup Whitespace.plist
@@ -7,7 +7,7 @@
 	<key>command</key>
 	<string>#!/bin/bash
 
-"${TM_PYTHON:-python}" "${TM_BUNDLE_SUPPORT}/cleanup_whitespace.py"</string>
+"${TM_PYTHON:-python2}" "${TM_BUNDLE_SUPPORT}/cleanup_whitespace.py"</string>
 	<key>input</key>
 	<string>selection</string>
 	<key>inputFormat</key>

--- a/Commands/Copy Symbol.tmCommand
+++ b/Commands/Copy Symbol.tmCommand
@@ -7,7 +7,7 @@
 	<key>bundleUUID</key>
 	<string>E3BADC20-6B0E-11D9-9DC9-000D93589AF6</string>
 	<key>command</key>
-	<string>#!/usr/bin/env python
+	<string>#!/usr/bin/env python2
 import sys
 import re
 import os

--- a/Commands/Documentation for Current Word.tmCommand
+++ b/Commands/Documentation for Current Word.tmCommand
@@ -16,7 +16,7 @@ export TM_FIRST_LINE="$first_line"
 export PYTHONPATH="$TM_BUNDLE_SUPPORT/DocMate"
 export PYTHONPATH="$TM_SUPPORT_PATH/lib:$PYTHONPATH"
 
-/usr/bin/env python -S - &lt;&lt;PYTHON
+/usr/bin/env python2 -S - &lt;&lt;PYTHON
 # coding: UTF-8
 import sys
 from sys import exit

--- a/Commands/Documentation in Browser.plist
+++ b/Commands/Documentation in Browser.plist
@@ -7,7 +7,7 @@
 	<key>command</key>
 	<string>#!/bin/bash
 
-TPY=${TM_PYTHON:-python}
+TPY=${TM_PYTHON:-python2}
 
 echo '&lt;html&gt;&lt;body&gt;'
 "$TPY" "${TM_BUNDLE_SUPPORT}/browse_pydocs.py"

--- a/Commands/Execute Line:Selection as Python.tmCommand
+++ b/Commands/Execute Line:Selection as Python.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env python
+	<string>#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import os

--- a/Commands/New Function.plist
+++ b/Commands/New Function.plist
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env python -S
+	<string>#!/usr/bin/env python2 -S
 # coding: utf-8
 
 # This program takes in the name of one of python's special methods, and

--- a/Commands/Run Project Unittests.plist
+++ b/Commands/Run Project Unittests.plist
@@ -15,7 +15,7 @@
 # Find all files that end with "Test.py" and run 
 # them.
 
-find . -name "*Test.py" -exec "${TM_PYTHON:-python}" '{}' \;|pre</string>
+find . -name "*Test.py" -exec "${TM_PYTHON:-python2}" '{}' \;|pre</string>
 	<key>fileCaptureRegister</key>
 	<string>1</string>
 	<key>input</key>

--- a/Commands/Run Script.plist
+++ b/Commands/Run Script.plist
@@ -38,7 +38,7 @@ TextMate::Executor.run(ENV["TM_PYTHON"] || "python", "-u", ENV["TM_FILEPATH"], :
       display_name = ENV["TM_DISPLAYNAME"]
       "#{htmlize(indent)}&lt;a class=\"near\" href=\"txmt://open?line=#{line + url}\"&gt;" +
         (method ? "method #{CGI::escapeHTML method}" : "&lt;em&gt;at top level&lt;/em&gt;") +
-        "&lt;/a&gt; in &lt;strong&gt;#{CGI::escapeHTML display_name}&lt;/strong&gt; at line #{line}&lt;br/&gt;\n"
+        "&lt;/a&gt; in &lt;strong&gt;#{CGI::escapeHTML(File.basename(file))}&lt;/strong&gt; at line #{line}&lt;br/&gt;\n"
     end
   end
 end</string>

--- a/Commands/Run Script.plist
+++ b/Commands/Run Script.plist
@@ -16,7 +16,7 @@ TextMate::Executor.make_project_master_current_document
 
 ENV["PYTHONPATH"] = ENV["TM_BUNDLE_SUPPORT"] + (ENV.has_key?("PYTHONPATH") ? ":" + ENV["PYTHONPATH"] : "")
 
-is_test_script = ENV["TM_FILEPATH"] =~ /(?:\b|_)(?:test)(?:\b|_)/ or
+is_test_script = ENV["TM_FILEPATH"] =~ /(?:\b|_)(?:test)(?:\b|_)/ ||
                  File.read(ENV["TM_FILEPATH"]) =~ /\bimport\b.+(?:unittest)/
 
 TextMate::Executor.run(ENV["TM_PYTHON"] || "python", "-u", ENV["TM_FILEPATH"], :create_error_pipe =&gt; true, :use_hashbang =&gt; !ENV.has_key?('TM_PYTHON')) do |str, type|

--- a/Commands/Show Symbol.tmCommand
+++ b/Commands/Show Symbol.tmCommand
@@ -7,7 +7,7 @@
 	<key>bundleUUID</key>
 	<string>E3BADC20-6B0E-11D9-9DC9-000D93589AF6</string>
 	<key>command</key>
-	<string>#!/usr/bin/env python
+	<string>#!/usr/bin/env python2
 import sys
 import re
 import os

--- a/Commands/Show Symbol.tmCommand
+++ b/Commands/Show Symbol.tmCommand
@@ -34,7 +34,7 @@ print symbol</string>
 	<key>input</key>
 	<string>document</string>
 	<key>keyEquivalent</key>
-	<string>^~p</string>
+	<string>^~c</string>
 	<key>name</key>
 	<string>Show Symbol</string>
 	<key>output</key>

--- a/Commands/super.tmCommand
+++ b/Commands/super.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env python
+	<string>#!/usr/bin/env python2
 import sys
 import os
 import ast

--- a/Snippets/#!:usr:bin:env python.tmSnippet
+++ b/Snippets/#!:usr:bin:env python.tmSnippet
@@ -3,10 +3,10 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>#!/usr/bin/env python
+	<string>#!/usr/bin/env python2
 </string>
 	<key>name</key>
-	<string>#!/usr/bin/env python</string>
+	<string>#!/usr/bin/env python2</string>
 	<key>scope</key>
 	<string>L:dyn.caret.begin.document</string>
 	<key>tabTrigger</key>

--- a/Support/bin/pycheckmate.py
+++ b/Support/bin/pycheckmate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # encoding: utf-8
 #
 # PyCheckMate, a PyChecker output beautifier for TextMate.

--- a/Support/browse_pydocs.py
+++ b/Support/browse_pydocs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # kumar.mcmillan at gmail
 
 import os

--- a/Support/cleanup_whitespace.py
+++ b/Support/cleanup_whitespace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import re

--- a/Templates/Python Class/template.py
+++ b/Templates/Python Class/template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # encoding: utf-8
 """
 ${TM_NEW_FILE_BASENAME}.py

--- a/Templates/Python Script with Args/template.py
+++ b/Templates/Python Script with Args/template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # encoding: utf-8
 """
 ${TM_NEW_FILE_BASENAME}.py

--- a/Templates/Python Script/template.py
+++ b/Templates/Python Script/template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # encoding: utf-8
 """
 ${TM_NEW_FILE_BASENAME}.py

--- a/Templates/Python Unittest/template.py
+++ b/Templates/Python Unittest/template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # encoding: utf-8
 """
 ${TM_NEW_FILE_BASENAME}.py


### PR DESCRIPTION
* Fix python scripts version to 2
* Change Show Symbol default shortcut to ^~c to avoid conflict with TextMate's Select Paragraph
* Display correct backtrace file names on Run Script
* Fix detection of "import unittest" files  on Run Script