### PR TITLE
Altered folding markers to match {}, (), []

### DIFF
--- a/Preferences/Folding.tmPreferences
+++ b/Preferences/Folding.tmPreferences
@@ -9,9 +9,9 @@
 	<key>settings</key>
 	<dict>
 		<key>foldingStartMarker</key>
-		<string>^\s*"""(?=.)(?!.*""")</string>
+		<string>^\s*"""(?=.)(?!.*""")|(\{|\(|\[)\s*(#.*)?$</string>
 		<key>foldingStopMarker</key>
-		<string>^\s*"""\s*$</string>
+		<string>^\s*"""\s*$|^\s*(\}|\)|\]),?\s*(#.*)?$</string>
 	</dict>
 	<key>uuid</key>
 	<string>7FD3FA0D-A907-4142-9A64-70A5DA366AA4</string>


### PR DESCRIPTION
TextMate 1.x folded code, even Python code, in {}, (), and []. This is pretty handy for long lists, constructor use, etc. The current default start/stop markers only fold on triple-quoted docstrings. I kept those patterns, but added to each one so they'll now also match on {}, (), and []. Supports lines with comments to the right of them, and closing markers followed by commas in case it's being declared as part of a longer list or tuple.