### PR TITLE
Import escape from html instead of cgi.

### DIFF
--- a/Support/bin/pycheckmate.py
+++ b/Support/bin/pycheckmate.py
@@ -26,7 +26,7 @@ import os
 import re
 import sys
 import traceback
-from cgi import escape
+from html import escape
 from select import select
 
 __version__ = "1.2"

--- a/Support/sitecustomize.py
+++ b/Support/sitecustomize.py
@@ -36,7 +36,7 @@ import codecs
 
 from os import environ, path, fdopen, popen
 from traceback import extract_tb
-from cgi import escape
+from html import escape
 
 try:
   from urllib import quote


### PR DESCRIPTION
`cgi.escape` was deprecated in Python 3.2 and removed from Python 3.8.

See https://docs.python.org/3/whatsnew/3.8.html#api-and-feature-removals:
> `parse_qs`, `parse_qsl`, and `escape` are removed from the `cgi` module. They are deprecated in Python 3.2 or older. They should be imported from the `urllib.parse` and `html` modules instead.

When running a Python script using the Python 3.8 interpreter, the output window contains the following error:

```
Error in sitecustomize; set PYTHONVERBOSE for traceback:
ImportError: cannot import name 'escape' from 'cgi' (/opt/local/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/cgi.py)
```

This PR fixes that issue.