### PR TITLE
Adopt new syntax elements (:=, match, case) and promote async and await to hard keywords

### DIFF
--- a/Syntaxes/Python.tmLanguage
+++ b/Syntaxes/Python.tmLanguage
@@ -1878,11 +1878,11 @@
 		<key>illegal_names</key>
 		<dict>
 			<key>comment</key>
-			<string>from Lib/keyword.py, in kwlist. `async` and `await` not keywords until Python 3.7 (according to PEP-0492)</string>
+			<string>from Lib/keyword.py, in kwlist.</string>
 			<key>match</key>
 			<string>(?x)
 				      \b (
-				        False | None | True | and | as | assert | break | class | continue | def |
+				        False | None | True | and | as | assert | async | await | break | class | continue | def |
 				        del | elif | else | except | exec | finally | for | from | global | if |
 				        import | in | is | lambda | nonlocal | not | or | pass | print | raise |
 				        return | try | while | with | yield | __debug__ )

--- a/Syntaxes/Python.tmLanguage
+++ b/Syntaxes/Python.tmLanguage
@@ -180,7 +180,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\=</string>
+			<string>\=|:\=</string>
 			<key>name</key>
 			<string>keyword.operator.assignment.python</string>
 		</dict>

--- a/Syntaxes/Python.tmLanguage
+++ b/Syntaxes/Python.tmLanguage
@@ -570,7 +570,7 @@
 			<string>(?x) \b(
 						async | await | break | continue | elif | else | except | finally | for |
 						if | pass | raise | return | try | while | with |
-						(yield(?:\s+from)?)
+						(yield(?:\s+from)?) | match | case
 					)\b
 					</string>
 			<key>name</key>


### PR DESCRIPTION
This adds some syntax elements that have been introduced lately:

* The walrus operator (Python 3.8).
* The pattern-matching keywords `match` and `case` (Python 3.10).

It also fixes the status of `await` and `async` as hard keywords (as they are since Python 3.7).
As to `match` and `case`, they are soft keywords (indefinitely), so I've not added them to the `illegal_names`.

Just like `async` and `await` during their soft-keyword period, `match` and `case` are picked anywhere they appear. It's odd. It would be nice to have the syntax discern between keyword and non-keyword uses at least most of the times. I don't know what would be the best way to achieve that (if feasible or worthwhile at all).

This pull request supersedes #79.