### PR TITLE
docs: Fix a few typos

### DIFF
--- a/Support/bin/pycheckmate.py
+++ b/Support/bin/pycheckmate.py
@@ -16,7 +16,7 @@
 #   "pychecker", "pyflakes", "pycodestyle", "flake8", or "pylint", or "frosted"
 #   to locate these programs in the default python bin directory or to a full
 #   path if the checker program is installed elsewhere.
-# - If for some reason you want to use the built-in sytax check when either
+# - If for some reason you want to use the built-in syntax check when either
 #   pychecker or pyflakes are installed, you may set TM_PYCHECKER to
 #   "builtin".
 
@@ -123,7 +123,7 @@ class MyPopen(object):
     return no additional output. At that point drain() should be called to
     return the last bit of output.
 
-    As a simplication, readlines() can be called until it returns (None, None)
+    As a simplification, readlines() can be called until it returns (None, None)
     """
 
     try:

--- a/Support/sitecustomize.py
+++ b/Support/sitecustomize.py
@@ -6,7 +6,7 @@ This file monkey-patches sys.excepthook to intercept any unhandled
 exceptions, format the exception in fancy html, and write them to
 a file handle (for instance, sys.stderr).
 
-Also, sys.stdout and sys.stder are wrapped in a utf-8 codec writer.
+Also, sys.stdout and sys.stderr are wrapped in a utf-8 codec writer.
 
 """
 


### PR DESCRIPTION
There are small typos in:
- Support/bin/pycheckmate.py
- Support/sitecustomize.py

Fixes:
- Should read `syntax` rather than `sytax`.
- Should read `stderr` rather than `stder`.
- Should read `simplification` rather than `simplication`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md