### PR TITLE
Folding for functions with parameters over multiple lines

### DIFF
--- a/Preferences/Folding Patterns.tmPreferences
+++ b/Preferences/Folding Patterns.tmPreferences
@@ -9,7 +9,9 @@
 	<key>settings</key>
 	<dict>
 		<key>foldingIndentedBlockStart</key>
-		<string>^\s*(class|def|async|for|while|if|elif|else|with|try|finally|except)\b.*(:|,|->|\\)\s*(#.*)?$</string>
+		<string>^\s*(class|def|async|for|while|if|elif|else|with|try|finally|except)\b.*(:|,|->|\\)\s*(#.*)?$|^\s*def\b.*\(\s*(#.*)?$</string>
+		<key>foldingIndentedBlockIgnore</key>
+		<string>^\s*\)(\s*->\s*\w.*)?:\s*(#.*)?$</string>
 	</dict>
 	<key>uuid</key>
 	<string>4A5DB35F-D647-4357-9D9B-57313710B95B</string>

--- a/Preferences/Folding.tmPreferences
+++ b/Preferences/Folding.tmPreferences
@@ -9,7 +9,7 @@
 	<key>settings</key>
 	<dict>
 		<key>foldingStartMarker</key>
-		<string>^\s*"""(?=.)(?!.*""")|(\{|\(|\[)\s*(#.*)?$</string>
+		<string>^\s*"""(?=.)(?!.*""")|(?<!\bdef\s+\w+\s*)(\{|\(|\[)\s*(#.*)?$</string>
 		<key>foldingStopMarker</key>
 		<string>^\s*"""\s*$|^\s*(\}|\)|\]),?\s*(#.*)?$</string>
 	</dict>

--- a/Preferences/Folding.tmPreferences
+++ b/Preferences/Folding.tmPreferences
@@ -9,7 +9,7 @@
 	<key>settings</key>
 	<dict>
 		<key>foldingStartMarker</key>
-		<string>^\s*"""(?=.)(?!.*""")|(?<!\bdef\s+\w+\s*)(\{|\(|\[)\s*(#.*)?$</string>
+		<string>^\s*"""(?=.)(?!.*""")|(\{|\[)\s*(#.*)?$|^(?!\s*def\s+\w+\s*).*\(\s*(#.*)?$</string>
 		<key>foldingStopMarker</key>
 		<string>^\s*"""\s*$|^\s*(\}|\)|\]),?\s*(#.*)?$</string>
 	</dict>


### PR DESCRIPTION
The default configuration fails to fold functions if the parameters are defined over multiple lines. Due to typing, this is more likely to happen these days than it used to be.

Three things here:

- a new regex for foldingIndentedBlockStart.

The existing expression only matches when the final : is on the same line as the 'def'. We don't want to lose that requirement for the other keywords that start a block, so I added a totally separate expression that matches only functions definitions with a open-parenthesis as the final non-whitespace non-comment character on the line.

`^\s*def\b.*\(\s*(#.*)?$`

- adding a foldingIndentedBlockIgnore expression

This is needed so that the closing parenthesis of the parameter declaration can be on a lower indent level, like black likes to do. It should match a closing parenthesis and colon with optional return type.

`^\s*\)(\s*->\s*\w.*)?:\s*(#.*)?$`

- modifying foldingStartMarker

Still not done, because Textmate also matches `def foo(\n` as the start of marker-based folding due to the parenthesis, and then it gets confused. The new foldingStartMarker
expression uses a negative-lookahead to match `(` only if it's not preceded by a def statement.

`^(?!\s*def\s+\w+\s*).*\(\s*(#.*)?$`

With those three changes in place, Textmate can now fold all functions, not just those with `def` and `):` on the same line!

The exact expressions can probably be fine-tuned a little further - I didn't fuss with them too much. I'm creating this MR more so anyone with the same issue might find it than in any expectation it'll get merged.